### PR TITLE
0715026 - Update PRF Controllers : Use PO net total in payment request views

### DIFF
--- a/src/main/java/ph/com/guanzongroup/integsys/views/PaymentRequest_ConfirmationController.java
+++ b/src/main/java/ph/com/guanzongroup/integsys/views/PaymentRequest_ConfirmationController.java
@@ -332,7 +332,7 @@ public class PaymentRequest_ConfirmationController implements Initializable, Scr
             tfAdvances.setText(CustomCommonUtil.setIntegerValueToDecimalFormat(poGLControllers.PaymentRequest().Master().PurchaseOrder().getAmountPaid(), true));
             tfSourceNo.setText(poGLControllers.PaymentRequest().Master().getSourceNo());
 
-            tfSourceTranTotal.setText(CustomCommonUtil.setIntegerValueToDecimalFormat(poGLControllers.PaymentRequest().Master().PurchaseOrder().getTranTotal(), true));
+            tfSourceTranTotal.setText(CustomCommonUtil.setIntegerValueToDecimalFormat(poGLControllers.PaymentRequest().Master().PurchaseOrder().getNetTotal(), true));
         } catch (SQLException | GuanzonException | NullPointerException ex) {
             Logger.getLogger(getClass().getName()).log(Level.SEVERE, null, ex);
         }

--- a/src/main/java/ph/com/guanzongroup/integsys/views/PaymentRequest_EntryController.java
+++ b/src/main/java/ph/com/guanzongroup/integsys/views/PaymentRequest_EntryController.java
@@ -354,7 +354,7 @@ public class PaymentRequest_EntryController implements Initializable, ScreenInte
             tfAdvances.setText(CustomCommonUtil.setIntegerValueToDecimalFormat(poGLControllers.PaymentRequest().Master().PurchaseOrder().getAmountPaid(), true));
             tfSourceNo.setText(poGLControllers.PaymentRequest().Master().getSourceNo());
 
-            tfSourceTranTotal.setText(CustomCommonUtil.setIntegerValueToDecimalFormat(poGLControllers.PaymentRequest().Master().PurchaseOrder().getTranTotal(), true));
+            tfSourceTranTotal.setText(CustomCommonUtil.setIntegerValueToDecimalFormat(poGLControllers.PaymentRequest().Master().PurchaseOrder().getNetTotal(), true));
         } catch (SQLException | GuanzonException | NullPointerException ex) {
             Logger.getLogger(getClass().getName()).log(Level.SEVERE, null, ex);
         }

--- a/src/main/java/ph/com/guanzongroup/integsys/views/PaymentRequest_HistoryController.java
+++ b/src/main/java/ph/com/guanzongroup/integsys/views/PaymentRequest_HistoryController.java
@@ -270,7 +270,7 @@ public class PaymentRequest_HistoryController implements Initializable, ScreenIn
             tfAdvances.setText(CustomCommonUtil.setIntegerValueToDecimalFormat(poGLControllers.PaymentRequest().Master().PurchaseOrder().getAmountPaid(), true));
             tfSourceNo.setText(poGLControllers.PaymentRequest().Master().getSourceNo());
 
-            tfSourceTranTotal.setText(CustomCommonUtil.setIntegerValueToDecimalFormat(poGLControllers.PaymentRequest().Master().PurchaseOrder().getTranTotal(), true));
+            tfSourceTranTotal.setText(CustomCommonUtil.setIntegerValueToDecimalFormat(poGLControllers.PaymentRequest().Master().PurchaseOrder().getNetTotal(), true));
         } catch (SQLException | GuanzonException | NullPointerException ex) {
             Logger.getLogger(getClass().getName()).log(Level.SEVERE, null, ex);
         }

--- a/src/main/java/ph/com/guanzongroup/integsys/views/PaymentRequest_ViewController.java
+++ b/src/main/java/ph/com/guanzongroup/integsys/views/PaymentRequest_ViewController.java
@@ -191,7 +191,7 @@ public class PaymentRequest_ViewController implements Initializable {
             tfAdvances.setText(CustomCommonUtil.setIntegerValueToDecimalFormat(poController.Master().PurchaseOrder().getAmountPaid(), true));
             tfSourceNo.setText(poController.Master().getSourceNo());
 
-            tfSourceTranTotal.setText(CustomCommonUtil.setIntegerValueToDecimalFormat(poController.Master().PurchaseOrder().getTranTotal(), true));
+            tfSourceTranTotal.setText(CustomCommonUtil.setIntegerValueToDecimalFormat(poController.Master().PurchaseOrder().getNetTotal(), true));
         } catch (SQLException | GuanzonException | NullPointerException ex) {
             Logger.getLogger(getClass().getName()).log(Level.SEVERE, null, ex);
         }


### PR DESCRIPTION
Updated all Payment Request controllers (Entry, Confirmation, History, and View) to display `PurchaseOrder.getNetTotal()` instead of `getTranTotal()` for `tfSourceTranTotal`. This aligns the shown source transaction total with the net amount used in payment request processing.